### PR TITLE
#105 ctors for ethprivatekey

### DIFF
--- a/Example/Tests/PrivateKey/EthPrivateKeyTests.swift
+++ b/Example/Tests/PrivateKey/EthPrivateKeyTests.swift
@@ -20,7 +20,8 @@ final class EthPrivateKeyTests: XCTestCase {
         }.to(
             equal(
                 Data(hex: "0xcD8aC90d9cc7e4c03430d58d2f3e87Dae70b807e")
-            )
+            ),
+            description: "Private key from bytes should compute correct public address"
         )
     }
     
@@ -34,7 +35,8 @@ final class EthPrivateKeyTests: XCTestCase {
         }.to(
             equal(
                 Data(hex: "0xcD8aC90d9cc7e4c03430d58d2f3e87Dae70b807e")
-            )
+            ),
+            description: "Private key from hex string should compute correct public address"
         )
     }
     
@@ -46,7 +48,8 @@ final class EthPrivateKeyTests: XCTestCase {
         }.to(
             equal(
                 Data(hex: "0xcD8aC90d9cc7e4c03430d58d2f3e87Dae70b807e")
-            )
+            ),
+            description: "Private key from hex should compute correct public address"
         )
     }
 

--- a/Example/Tests/PrivateKey/EthPrivateKeyTests.swift
+++ b/Example/Tests/PrivateKey/EthPrivateKeyTests.swift
@@ -31,7 +31,7 @@ final class EthPrivateKeyTests: XCTestCase {
                 hex: SimpleString{
                     "0x1636e10756e62baabddd4364010444205f1216bdb1644ff8f776f6e2982aa9f5"
                 }
-                ).address().value()
+            ).address().value()
         }.to(
             equal(
                 Data(hex: "0xcD8aC90d9cc7e4c03430d58d2f3e87Dae70b807e")
@@ -44,7 +44,7 @@ final class EthPrivateKeyTests: XCTestCase {
         expect{
             try EthPrivateKey(
                 hex: "0x1636e10756e62baabddd4364010444205f1216bdb1644ff8f776f6e2982aa9f5"
-                ).address().value()
+            ).address().value()
         }.to(
             equal(
                 Data(hex: "0xcD8aC90d9cc7e4c03430d58d2f3e87Dae70b807e")

--- a/Example/Tests/PrivateKey/EthPrivateKeyTests.swift
+++ b/Example/Tests/PrivateKey/EthPrivateKeyTests.swift
@@ -23,5 +23,31 @@ final class EthPrivateKeyTests: XCTestCase {
             )
         )
     }
+    
+    func testValidStringScalarPrivateKey() {
+        expect{
+            try EthPrivateKey(
+                hex: SimpleString{
+                    "0x1636e10756e62baabddd4364010444205f1216bdb1644ff8f776f6e2982aa9f5"
+                }
+                ).address().value()
+        }.to(
+            equal(
+                Data(hex: "0xcD8aC90d9cc7e4c03430d58d2f3e87Dae70b807e")
+            )
+        )
+    }
+    
+    func testValidStringPrivateKey() {
+        expect{
+            try EthPrivateKey(
+                hex: "0x1636e10756e62baabddd4364010444205f1216bdb1644ff8f776f6e2982aa9f5"
+                ).address().value()
+        }.to(
+            equal(
+                Data(hex: "0xcD8aC90d9cc7e4c03430d58d2f3e87Dae70b807e")
+            )
+        )
+    }
 
 }

--- a/Web3Swift/PrivateKey/EthPrivateKey.swift
+++ b/Web3Swift/PrivateKey/EthPrivateKey.swift
@@ -39,6 +39,34 @@ public final class EthPrivateKey: PrivateKey {
             length: 32
         )
     }
+    
+    /**
+     Ctor
+     
+     - parameters:
+     - hex: `StringScalar` representing bytes of the address in hex format
+     */
+    convenience init(hex: StringScalar) {
+        self.init(
+            bytes: BytesFromHexString(
+                hex: hex
+            )
+        )
+    }
+    
+    /**
+     Ctor
+     
+     - parameters:
+     - hex: `String` representing bytes of the address in hex format
+     */
+    convenience init(hex: String) {
+        self.init(
+            hex: SimpleString{
+                hex
+            }
+        )
+    }
 
     /**
     - returns:

--- a/Web3Swift/PrivateKey/EthPrivateKey.swift
+++ b/Web3Swift/PrivateKey/EthPrivateKey.swift
@@ -44,7 +44,7 @@ public final class EthPrivateKey: PrivateKey {
      Ctor
      
      - parameters:
-     - hex: `StringScalar` representing bytes of the address in hex format
+        - hex: `StringScalar` representing bytes of the address in hex format
      */
     convenience init(hex: StringScalar) {
         self.init(
@@ -58,7 +58,7 @@ public final class EthPrivateKey: PrivateKey {
      Ctor
      
      - parameters:
-     - hex: `String` representing bytes of the address in hex format
+        - hex: `String` representing bytes of the address in hex format
      */
     convenience init(hex: String) {
         self.init(


### PR DESCRIPTION
Solves #105 
Adds two new ctors for the private key to create it from `StringScalar` and `string`